### PR TITLE
Auto create folders

### DIFF
--- a/src/LaravelSamlServiceProvider.php
+++ b/src/LaravelSamlServiceProvider.php
@@ -42,6 +42,11 @@ class LaravelSamlServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__ . '/config/saml.php' => config_path('saml.php'),
             ], 'saml_config');
+            
+            // Create storage/saml directory
+            if (!file_exists(storage_path() . "/saml/idp")) {
+                mkdir(storage_path() . "/saml/idp", 0755, true);
+            }
         }
     }
 

--- a/src/LaravelSamlServiceProvider.php
+++ b/src/LaravelSamlServiceProvider.php
@@ -3,6 +3,7 @@
 namespace KingStarter\LaravelSaml;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Foundation\Application as LaravelApplication;
 use Config;
 
 class LaravelSamlServiceProvider extends ServiceProvider
@@ -14,15 +15,8 @@ class LaravelSamlServiceProvider extends ServiceProvider
      */
 	public function boot()
 	{
-	    // Publishing configurations
-		$this->publishes([
-            __DIR__ . '/config/saml.php' => config_path('saml.php'),
-		], 'saml_config');
-
-	    // Routing
-        if (Config::get('saml.use_package_routes')) {
-            require __DIR__ . '/routes.php';
-        }
+        $this->bootInConsole();
+        $this->loadPackageRoutes();
     }
 
     /**
@@ -36,5 +30,28 @@ class LaravelSamlServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/config/saml.php', 'saml'
         );
+    }
+
+    /**
+     * Perform various commands only if within console
+     */
+    protected function bootInConsole()
+    {
+        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
+            // Publishing configurations
+            $this->publishes([
+                __DIR__ . '/config/saml.php' => config_path('saml.php'),
+            ], 'saml_config');
+        }
+    }
+
+    /**
+     * Load package's routes into application
+     */
+    protected function loadPackageRoutes()
+    {
+        if (Config::get('saml.use_package_routes')) {
+            $this->loadRoutesFrom(__DIR__ . '/routes.php');
+        }
     }
 }


### PR DESCRIPTION
LaravelSamlServiceProvider changed to only run console related things in console. Added auto-creation of saml/idp folder within storage path. Switched to using Laravel's loadRoutesFrom method instead of including file.