### PR TITLE
Add relay state to response

### DIFF
--- a/src/LaravelSamlServiceProvider.php
+++ b/src/LaravelSamlServiceProvider.php
@@ -3,6 +3,7 @@
 namespace KingStarter\LaravelSaml;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Foundation\Application as LaravelApplication;
 use Config;
 
 class LaravelSamlServiceProvider extends ServiceProvider
@@ -14,15 +15,8 @@ class LaravelSamlServiceProvider extends ServiceProvider
      */
 	public function boot()
 	{
-	    // Publishing configurations
-		$this->publishes([
-            __DIR__ . '/config/saml.php' => config_path('saml.php'),
-		], 'saml_config');
-
-	    // Routing
-        if (Config::get('saml.use_package_routes')) {
-            require __DIR__ . '/routes.php';
-        }
+        $this->bootInConsole();
+        $this->loadPackageRoutes();
     }
 
     /**
@@ -36,5 +30,28 @@ class LaravelSamlServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/config/saml.php', 'saml'
         );
+    }
+
+    /**
+     * Perform various commands only if within console
+     */
+    protected function bootInConsole()
+    {
+        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
+            // Publishing configurations
+            $this->publishes([
+                __DIR__ . '/config/saml.php' => config_path('saml.php'),
+            ], 'saml_config');
+        }
+    }
+
+    /**
+     * Load package's routes into application
+     */
+    protected function loadPackageRoutes()
+    {
+        if (Config::get('saml.use_package_routes')) {
+            $this->loadRoutesFrom(__DIR__ . '/routes.php');
+        }
     }
 }


### PR DESCRIPTION
Re-submission of a previous PR. Add pass-thru of RelayState back to SP if received with the original login request. Re-submitting as I had to make changes to my fork for a few other PRs I would like to submit.

As per SAML Spec, if RelayState is given, this must be passed back to the SP as is.

As Per official SAML docs (http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html):
**5.1.1**
> a binding-specific field called RelayState is used to coordinate messages and actions of IdPs and SPs, for example, to allow an IdP (with which SSO was initiated) to indicate the URL of a desired resource when communicating with an SP.

**5.1.2.5**
> If the IdP received a RelayState value from the SP, it must return it unmodified to the SP in a hidden form control named RelayState. The Single Sign-On Service sends the HTML form back to the browser in the HTTP response.

RelayState can be used by SP to pass back after login the intended URL among other things such as tokens.

Not sure if storing this in session is the best approach but works well.